### PR TITLE
Enable concurrent scraping

### DIFF
--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -2,6 +2,65 @@
   "schemaVersion": 1,
   "title": "Bridge input",
   "type": "object",
-  "properties": {},
-  "required": []
+  "properties": {
+    "datagolUrl": {
+      "title": "DataGOL URL",
+      "type": "string",
+      "description": "URL of the DataGOL endpoint."
+    },
+    "datagolToken": {
+      "title": "DataGOL token",
+      "type": "string",
+      "description": "Authentication token for the endpoint."
+    },
+    "rows": {
+      "title": "Rows",
+      "type": "integer",
+      "default": 10,
+      "description": "Number of results to fetch per query."
+    },
+    "scraperTimeoutSecs": {
+      "title": "Scraper timeout (secs)",
+      "type": "integer",
+      "default": 3600,
+      "description": "Maximum seconds to wait for each LinkedIn scraper run (max 3600)."
+    },
+    "jobTitles": {
+      "title": "Job titles",
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [
+        "Financial controller",
+        "Business controller",
+        "Financial analyst",
+        "FP&A",
+        "Finance Business Partner",
+        "Contr\u00f4leur de gestion",
+        "Analyste Financier",
+        "Financieel analist",
+        "Financieel controller",
+        "Accountant",
+        "comptable",
+        "boekhouder",
+        "gestionnaire de dossiers",
+        "dossierbeheerder"
+      ],
+      "description": "Job titles to search for."
+    },
+    "locations": {
+      "title": "Locations",
+      "type": "array",
+      "items": { "type": "string" },
+      "default": [
+        "Brussels",
+        "Namur",
+        "Charleroi",
+        "Li\u00e8ge",
+        "Mons",
+        "Arlon"
+      ],
+      "description": "Locations to search for."
+    }
+  },
+  "required": ["datagolUrl", "datagolToken"]
 }

--- a/README.md
+++ b/README.md
@@ -3,8 +3,11 @@
 This actor collects job postings from LinkedIn and forwards them to a DataGOL instance. It
 runs the `bebity/linkedin-jobs-scraper` actor for each job title and location listed in
 `src/scraperInput.js`, filters out postings from companies listed in `src/excludedCompanies.js`
-and posts the remaining jobs to DataGOL using HTTP requests. Results for each title/location
-pair are sent as soon as their scraper run finishes.
+and posts the remaining jobs to DataGOL using HTTP requests. Scraper runs for all
+title/location pairs are executed in parallel and results are forwarded as soon as
+each run finishes.
+Each LinkedIn scraper run is started with only 256&nbsp;MB of memory and
+will be aborted if it runs longer than 3600&nbsp;seconds (60&nbsp;minutes).
 
 ## Usage
 
@@ -12,18 +15,24 @@ pair are sent as soon as their scraper run finishes.
    ```bash
    npm install
    ```
-2. Set the following environment variables:
-   - `DATAGOL_URL` – URL of the DataGOL endpoint
-   - `DATAGOL_TOKEN` – authentication token for the endpoint
-   - `ROWS` *(optional)* – number of results to fetch for each query (default: 10)
-   - `SCRAPER_TIMEOUT_SECS` *(optional)* – max seconds to wait for the LinkedIn scraper
+2. Prepare `input.json` with your parameters, for example:
+   ```json
+  {
+    "datagolUrl": "https://example.com/api",
+    "datagolToken": "<TOKEN>",
+    "rows": 10,
+    "scraperTimeoutSecs": 3600,
+    "jobTitles": ["Financial controller"],
+    "locations": ["Brussels"]
+  }
+  ```
+   (3600 seconds equals 60 minutes.)
 3. Run the actor
    ```bash
    npm start
    ```
 
-The actor does not require any input fields – it uses the data defined in the source files.
-You can adjust job titles and locations directly in `src/scraperInput.js`. The number of rows can be changed by setting the `ROWS` environment variable or editing `src/scraperInput.js`.
+All parameters can also be passed via the Apify platform UI. When not provided, the defaults from `src/scraperInput.js` are used.
 
 ## Development
 

--- a/src/main.js
+++ b/src/main.js
@@ -1,58 +1,73 @@
 import { Actor } from 'apify';
 import got from 'got';
 import { EXCLUDED_COMPANIES } from './excludedCompanies.js';
-import { JOB_TITLES, LOCATIONS, ROWS } from './scraperInput.js';
+import { JOB_TITLES as DEFAULT_JOB_TITLES, LOCATIONS as DEFAULT_LOCATIONS, ROWS as DEFAULT_ROWS } from './scraperInput.js';
 import { buildReportRow } from './reportBase.js';
 
-const scraperTimeoutEnv = parseInt(process.env.SCRAPER_TIMEOUT_SECS ?? '', 10);
-const SCRAPER_TIMEOUT = Number.isFinite(scraperTimeoutEnv) ? scraperTimeoutEnv : undefined;
-
 export default Actor.main(async () => {
-    const url = process.env.DATAGOL_URL;
-    const token = process.env.DATAGOL_TOKEN;
+    const input = await Actor.getInput() ?? {};
 
-    for (const title of JOB_TITLES) {
-        for (const location of LOCATIONS) {
-            const input = { title, location, rows: ROWS };
-            console.log(`Running LinkedIn jobs scraper with input: ${JSON.stringify(input)}`);
+    const url = input.datagolUrl ?? process.env.DATAGOL_URL;
+    const token = input.datagolToken ?? process.env.DATAGOL_TOKEN;
 
-            const { defaultDatasetId } = await Actor.call('bebity/linkedin-jobs-scraper', input, { timeout: SCRAPER_TIMEOUT });
-            const { items } = await Actor.openDataset(defaultDatasetId).then(ds => ds.getData());
+    const titles = Array.isArray(input.jobTitles) && input.jobTitles.length ? input.jobTitles : DEFAULT_JOB_TITLES;
+    const locations = Array.isArray(input.locations) && input.locations.length ? input.locations : DEFAULT_LOCATIONS;
 
-            if (items.length === 0) {
-                console.log('Nothing to forward — dataset empty.');
-                continue;
-            }
+    const rows = Number.isFinite(input.rows) ? input.rows : DEFAULT_ROWS;
 
-            const filteredItems = items.filter(job => !EXCLUDED_COMPANIES.includes((job.companyName ?? '').trim()));
-            if (filteredItems.length === 0) {
-                console.log('Nothing to forward — all jobs excluded by company name.');
-                continue;
-            }
+    const scraperTimeoutEnv = parseInt(input.scraperTimeoutSecs ?? process.env.SCRAPER_TIMEOUT_SECS ?? '3600', 10);
+    const SCRAPER_TIMEOUT = Number.isFinite(scraperTimeoutEnv) ? Math.min(scraperTimeoutEnv, 3600) : 3600;
 
-            const rows = filteredItems.map(buildReportRow);
-
-            console.log(`\n--- About to POST ${rows.length} row(s) to DataGOL at:\n   ${url}\n--- Using token prefix: ${token?.slice(0, 6)}\n`);
-
-            for (const [i, row] of rows.entries()) {
-                console.log(`→ [${i + 1}/${rows.length}]`, JSON.stringify(row).slice(0, 200) + '…');
-                try {
-                    const resp = await got.post(url, {
-                        headers: {
-                            'x-auth-token': token,
-                            'Accept': '*/*',
-                            'Content-Type': 'application/json',
-                        },
-                        json: row,
-                        throwHttpErrors: false,
-                    });
-                    console.log(`  ✔ status=${resp.statusCode}`, resp.body);
-                } catch (err) {
-                    console.error(`  ✖ Exception:`, err.message);
-                }
-            }
-
-            console.log(`\n✅ Finished processing ${rows.length} row(s) for input ${JSON.stringify(input)}\n`);
+    const runInputs = [];
+    for (const title of titles) {
+        for (const location of locations) {
+            runInputs.push({ title, location, rows });
         }
     }
+
+    await Promise.all(runInputs.map(async (scraperInput) => {
+        console.log(`Running LinkedIn jobs scraper with input: ${JSON.stringify(scraperInput)}`);
+
+        const { defaultDatasetId } = await Actor.call('bebity/linkedin-jobs-scraper', scraperInput, {
+            memoryMbytes: 256,
+            timeoutSecs: SCRAPER_TIMEOUT,
+        });
+
+        const { items } = await Actor.openDataset(defaultDatasetId).then(ds => ds.getData());
+
+        if (items.length === 0) {
+            console.log('Nothing to forward — dataset empty.');
+            return;
+        }
+
+        const filteredItems = items.filter(job => !EXCLUDED_COMPANIES.includes((job.companyName ?? '').trim()));
+        if (filteredItems.length === 0) {
+            console.log('Nothing to forward — all jobs excluded by company name.');
+            return;
+        }
+
+        const rowsArr = filteredItems.map(buildReportRow);
+
+        console.log(`\n--- About to POST ${rowsArr.length} row(s) to DataGOL at:\n   ${url}\n--- Using token prefix: ${token?.slice(0, 6)}\n`);
+
+        for (const [i, row] of rowsArr.entries()) {
+            console.log(`→ [${i + 1}/${rowsArr.length}]`, JSON.stringify(row).slice(0, 200) + '…');
+            try {
+                const resp = await got.post(url, {
+                    headers: {
+                        'x-auth-token': token,
+                        'Accept': '*/*',
+                        'Content-Type': 'application/json',
+                    },
+                    json: row,
+                    throwHttpErrors: false,
+                });
+                console.log(`  ✔ status=${resp.statusCode}`, resp.body);
+            } catch (err) {
+                console.error(`  ✖ Exception:`, err.message);
+            }
+        }
+
+        console.log(`\n✅ Finished processing ${rowsArr.length} row(s) for input ${JSON.stringify(scraperInput)}\n`);
+    }));
 });


### PR DESCRIPTION
## Summary
- run LinkedIn scraper calls concurrently
- set 3600 sec timeout with 256 MB memory
- allow actor parameters via `input.json`
- document new usage

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a74d4bcb48321bd6cc8c5acc9497a