### PR TITLE
Fix input schema validation error

### DIFF
--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -32,14 +32,13 @@
     "jobTitles": {
       "title": "Job titles",
       "type": "array",
-      "items": { "type": "string" },
       "default": [
         "Financial controller",
         "Business controller",
         "Financial analyst",
         "FP&A",
         "Finance Business Partner",
-        "Contr\u00f4leur de gestion",
+        "Contrôleur de gestion",
         "Analyste Financier",
         "Financieel analist",
         "Financieel controller",
@@ -49,21 +48,22 @@
         "gestionnaire de dossiers",
         "dossierbeheerder"
       ],
-      "description": "Job titles to search for."
+      "description": "Job titles to search for.",
+      "editor": "stringList"
     },
     "locations": {
       "title": "Locations",
       "type": "array",
-      "items": { "type": "string" },
       "default": [
         "Brussels",
         "Namur",
         "Charleroi",
-        "Li\u00e8ge",
+        "Liège",
         "Mons",
         "Arlon"
       ],
-      "description": "Locations to search for."
+      "description": "Locations to search for.",
+      "editor": "stringList"
     }
   },
   "required": []


### PR DESCRIPTION
## Summary
- mark `jobTitles` and `locations` arrays as `stringList`
- remove `items` field so the schema conforms to Apify's validation rules

## Testing
- `npm test`
- `apify validate-schema .actor/input_schema.json`


------
https://chatgpt.com/codex/tasks/task_e_685a7e3e000c8321b98d7158f4ec3410