### PR TITLE
Fix Apify memory option

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -29,7 +29,7 @@ export default Actor.main(async () => {
         console.log(`Running LinkedIn jobs scraper with input: ${JSON.stringify(scraperInput)}`);
 
         const { defaultDatasetId } = await Actor.call('bebity/linkedin-jobs-scraper', scraperInput, {
-            memoryMbytes: 256,
+            memory: 256,
             timeoutSecs: SCRAPER_TIMEOUT,
         });
 


### PR DESCRIPTION
## Summary
- use `memory` instead of `memoryMbytes` when calling an actor

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a811503bc8321b2ba3cb853453b99