### PR TITLE
Fix actor call timeout option

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -30,7 +30,7 @@ export default Actor.main(async () => {
 
         const { defaultDatasetId } = await Actor.call('bebity/linkedin-jobs-scraper', scraperInput, {
             memory: 256,
-            timeoutSecs: SCRAPER_TIMEOUT,
+            timeout: SCRAPER_TIMEOUT,
         });
 
         const { items } = await Actor.openDataset(defaultDatasetId).then(ds => ds.getData());


### PR DESCRIPTION
## Summary
- switch to the `timeout` option when calling the LinkedIn scraper actor

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685a82ff992c8321b532217e464168f6