### PR TITLE
Limit concurrency and update defaults

### DIFF
--- a/.actor/input_schema.json
+++ b/.actor/input_schema.json
@@ -26,8 +26,8 @@
     "scraperTimeoutSecs": {
       "title": "Scraper timeout (secs)",
       "type": "integer",
-      "default": 3600,
-      "description": "Maximum seconds to wait for each LinkedIn scraper run (max 3600)."
+      "default": 600,
+      "description": "Maximum seconds to wait for each LinkedIn scraper run (max 3600, default 600)."
     },
     "jobTitles": {
       "title": "Job titles",

--- a/README.md
+++ b/README.md
@@ -4,10 +4,13 @@ This actor collects job postings from LinkedIn and forwards them to a DataGOL in
 runs the `bebity/linkedin-jobs-scraper` actor for each job title and location listed in
 `src/scraperInput.js`, filters out postings from companies listed in `src/excludedCompanies.js`
 and posts the remaining jobs to DataGOL using HTTP requests. Scraper runs for all
-title/location pairs are executed in parallel and results are forwarded as soon as
-each run finishes.
+title/location pairs are executed in batches of 24 in parallel due to the platform's
+concurrent run limit, and results are forwarded as soon as
+each batch finishes.
 Each LinkedIn scraper run is started with only 256&nbsp;MB of memory and
-will be aborted if it runs longer than 3600&nbsp;seconds (60&nbsp;minutes).
+will be aborted if it runs longer than 600&nbsp;seconds (10&nbsp;minutes by default).
+When scheduling this actor, set its run timeout to at least the scraper timeout
+multiplied by the number of batches plus 120&nbsp;seconds so the bridge has enough time to finish.
 
 ## Usage
 
@@ -21,12 +24,12 @@ will be aborted if it runs longer than 3600&nbsp;seconds (60&nbsp;minutes).
     "datagolUrl": "https://example.com/api",
     "datagolToken": "<TOKEN>",
     "rows": 10,
-    "scraperTimeoutSecs": 3600,
+    "scraperTimeoutSecs": 600,
     "jobTitles": ["Financial controller"],
     "locations": ["Brussels"]
   }
   ```
-   (3600 seconds equals 60 minutes.)
+   (600 seconds equals 10 minutes.)
 3. Run the actor
    ```bash
    npm start


### PR DESCRIPTION
## Summary
- set default scraper timeout to 600 seconds
- limit scraper runs to batches of 24
- warn if the actor run timeout is less than the batches need by 120 seconds
- document new defaults and concurrency requirements

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685a850d1c908321b47a0081795b326d