### PR TITLE
Fix fetcher timeouts

### DIFF
--- a/src/fetchers.js
+++ b/src/fetchers.js
@@ -68,7 +68,7 @@ export const fetchJobTitles = async () => {
                     }
                 },
                 responseType: 'json',
-                timeout: 10000
+                timeout: { request: 10000 }
             }
         );
 
@@ -108,7 +108,7 @@ export const fetchCompetitorList = async () => {
                     }
                 },
                 responseType: 'json',
-                timeout: 10000
+                timeout: { request: 10000 }
             }
         );
 
@@ -151,7 +151,7 @@ export const fetchLocations = async () => {
                     }
                 },
                 responseType: 'json',
-                timeout: 10000
+                timeout: { request: 10000 }
             }
         );
 


### PR DESCRIPTION
## Summary
- fix 'plain object' error by passing timeout as an object to got

## Testing
- `npm test`
- `node -e "import('./src/fetchers.js').then(async f => {console.log(await f.fetchJobTitles()); console.log(await f.fetchCompetitorList()); console.log(await f.fetchLocations());}).catch(e => console.error(e))"`

------
https://chatgpt.com/codex/tasks/task_e_68627b3aa4488321b8f4af0fcb82ba2e